### PR TITLE
Fix conv layout + NCHW input so enable_inst_interactivity (box-prompt) path runs

### DIFF
--- a/sam3/model/geometry_encoders.py
+++ b/sam3/model/geometry_encoders.py
@@ -512,8 +512,6 @@ class SequenceGeometryEncoder(nn.Module):
                 self.roi_size,
                 self.roi_size,
             ]
-            # roi_align liefert NCHW; MLX-Conv2d erwartet channels-last (NHWC). Vor der Conv
-            # permutieren -> Output (B,1,1,d_model), d_model bleibt letzte Achse, Reshape passt.
             sampled = mx.transpose(sampled, (0, 2, 3, 1))
             proj = self.boxes_pool_project(sampled)
             proj = proj.reshape(bs, n_boxes, self.d_model).transpose(1, 0, 2)

--- a/sam3/model/geometry_encoders.py
+++ b/sam3/model/geometry_encoders.py
@@ -512,6 +512,9 @@ class SequenceGeometryEncoder(nn.Module):
                 self.roi_size,
                 self.roi_size,
             ]
+            # roi_align liefert NCHW; MLX-Conv2d erwartet channels-last (NHWC). Vor der Conv
+            # permutieren -> Output (B,1,1,d_model), d_model bleibt letzte Achse, Reshape passt.
+            sampled = mx.transpose(sampled, (0, 2, 3, 1))
             proj = self.boxes_pool_project(sampled)
             proj = proj.reshape(bs, n_boxes, self.d_model).transpose(1, 0, 2)
             if boxes_embed is None:

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -272,8 +272,40 @@ def _create_sam3_transformer(has_presence_token: bool = True):
 
     return TransformerWrapper(encoder=encoder, decoder=decoder, d_model=256)
 
+def _sanitize_conv_layout(model, weights):
+    """Korrigiert Conv-Gewichte, die in den veröffentlichten mlx-community/sam3-image-Gewichten
+    noch im PyTorch-Layout (channels-first) liegen. `convert.py` transponiert per fest verdrahteter
+    Key-Liste NUR die `convs.*` des SAM-3-Necks, NICHT deren `sam2_convs.*`-Zwillinge (zweiter Neck,
+    nur bei enable_inst_interactivity=True gebaut) und nicht `geometry_encoder.boxes_pool_project`.
+    Folge: bei aktivem Interaktiv-Pfad crasht `set_image` in necks.py `mx.conv_transpose2d`
+    (Channel-Mismatch). MLX-Convs sind channels-last → hier shape-getrieben + idempotent permutieren:
+      • nur anfassen, wenn die geladene Shape von der Modell-Soll-Shape abweicht (4D),
+      • ConvTranspose (`dconv`): PyTorch (Cin,Cout,kH,kW) -> MLX (Cout,kH,kW,Cin) = transpose(1,2,3,0),
+      • normale Conv (`conv_*`/`*_project`/`patch_embed.proj`): (Cout,Cin,kH,kW) -> (Cout,kH,kW,Cin)
+        = transpose(0,2,3,1)  (Key-Semantik nötig: bei quadratischen Convs ist die Shape mehrdeutig).
+    Bereits korrekt konvertierte Gewichte (Shape == Soll) bleiben unberührt. Siehe SAM3_FIX_NOTES.md."""
+    from mlx.utils import tree_flatten
+    expected = {k: tuple(v.shape) for k, v in tree_flatten(model.parameters())}
+    fixed = []
+    for k in list(weights.keys()):
+        exp = expected.get(k)
+        v = weights[k]
+        if exp is None or v.ndim != 4 or tuple(v.shape) == exp:
+            continue
+        perm = (1, 2, 3, 0) if "dconv" in k else (0, 2, 3, 1)
+        cand = mx.transpose(v, perm)
+        if tuple(cand.shape) == exp:
+            weights[k] = cand
+            fixed.append(k)
+    if fixed:
+        print(f"[sam3] Conv-Layout saniert: {len(fixed)} Gewichte PyTorch->MLX permutiert "
+              f"(sam2_convs/geometry — s. SAM3_FIX_NOTES.md)")
+    return weights
+
+
 def load_checkpoint(model, checkpoint_path):
     weights = mx.load(checkpoint_path)
+    weights = _sanitize_conv_layout(model, weights)
     try:
         model.load_weights(weights, strict=False)
         mx.eval(model.parameters())

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -273,20 +273,8 @@ def _create_sam3_transformer(has_presence_token: bool = True):
     return TransformerWrapper(encoder=encoder, decoder=decoder, d_model=256)
 
 def _sanitize_conv_layout(model, weights):
-    """Korrigiert Conv-Gewichte, die in den veröffentlichten mlx-community/sam3-image-Gewichten
-    noch im PyTorch-Layout (channels-first) liegen. `convert.py` transponiert per fest verdrahteter
-    Key-Liste NUR die `convs.*` des SAM-3-Necks, NICHT deren `sam2_convs.*`-Zwillinge (zweiter Neck,
-    nur bei enable_inst_interactivity=True gebaut) und nicht `geometry_encoder.boxes_pool_project`.
-    Folge: bei aktivem Interaktiv-Pfad crasht `set_image` in necks.py `mx.conv_transpose2d`
-    (Channel-Mismatch). MLX-Convs sind channels-last → hier shape-getrieben + idempotent permutieren:
-      • nur anfassen, wenn die geladene Shape von der Modell-Soll-Shape abweicht (4D),
-      • ConvTranspose (`dconv`): PyTorch (Cin,Cout,kH,kW) -> MLX (Cout,kH,kW,Cin) = transpose(1,2,3,0),
-      • normale Conv (`conv_*`/`*_project`/`patch_embed.proj`): (Cout,Cin,kH,kW) -> (Cout,kH,kW,Cin)
-        = transpose(0,2,3,1)  (Key-Semantik nötig: bei quadratischen Convs ist die Shape mehrdeutig).
-    Bereits korrekt konvertierte Gewichte (Shape == Soll) bleiben unberührt. Siehe SAM3_FIX_NOTES.md."""
     from mlx.utils import tree_flatten
     expected = {k: tuple(v.shape) for k, v in tree_flatten(model.parameters())}
-    fixed = []
     for k in list(weights.keys()):
         exp = expected.get(k)
         v = weights[k]
@@ -296,10 +284,6 @@ def _sanitize_conv_layout(model, weights):
         cand = mx.transpose(v, perm)
         if tuple(cand.shape) == exp:
             weights[k] = cand
-            fixed.append(k)
-    if fixed:
-        print(f"[sam3] Conv-Layout saniert: {len(fixed)} Gewichte PyTorch->MLX permutiert "
-              f"(sam2_convs/geometry — s. SAM3_FIX_NOTES.md)")
     return weights
 
 


### PR DESCRIPTION
## What

`build_sam3_image_model(enable_inst_interactivity=True)` + `Sam3Processor.add_geometric_prompt(box)`
crashes on the published `mlx-community/sam3-image` weights. Two independent bugs:

1. **Conv weight layout.** `convert.py` transposes the SAM-3 neck `convs.*` weights to MLX
   channels-last via a hard-coded key list, but not their `sam2_convs.*` twins (the second neck,
   built only when `add_sam2_neck=True` / `enable_inst_interactivity=True`) nor
   `geometry_encoder.boxes_pool_project`. So 12 weights are published in PyTorch (channels-first)
   layout and `set_image` crashes in `necks.py` `mx.conv_transpose2d`
   (`input (1,72,72,1024)` vs `weight (1024,512,2,2)`).

2. **NCHW input into an MLX Conv2d.** After (1), `add_geometric_prompt` crashes one level down:
   `geometry_encoders._encode_boxes` feeds the NCHW `roi_align` output `(B,256,7,7)` straight into
   the `boxes_pool_project` Conv2d, which expects NHWC.

The `/label`-style text path doesn't build `sam2_convs`, so it was never affected — which is why
this only shows up with `enable_inst_interactivity=True`.

## Fix

- `model_builder.load_checkpoint`: new `_sanitize_conv_layout()` runs before `load_weights`.
  Shape-driven + idempotent — for any 4D weight whose loaded shape != the model's expected shape,
  it transposes `dconv` via `(1,2,3,0)` and other convs via `(0,2,3,1)` (key-based, because square
  convs are shape-ambiguous). Already-correct weights are left untouched, so it's a no-op once the
  published weights are re-converted correctly. This fixes the currently-published weights at load time.
- `geometry_encoders._encode_boxes`: transpose `sampled` NCHW->NHWC before `boxes_pool_project`
  (the output reshape stays correct, `d_model` remains the last axis).

A cleaner root-cause fix for (1) would be to make `convert.py` itself key-/shape-driven instead of
hard-coded, so a re-convert produces correct weights and the published safetensors can be
regenerated. Happy to follow up on that if you prefer.

## Verification

`set_image` + `add_geometric_prompt(box)` produce clean masks on Apple M5 Pro / MLX
(`mlx-community/sam3-image`): box prompts around a person / stool / door each return coherent
single-object masks with confidence 0.9+.
