### PR TITLE
Derive conv weight layout from the model in convert.py (root-cause fix for #9)

### DIFF
--- a/sam3/convert.py
+++ b/sam3/convert.py
@@ -89,74 +89,84 @@ def update_attn_keys(key, mlx_weights):
         }
         mlx_weights.update(new_dict)
         
+# vision and language backbone, transformer fusion encoder / detr decoder,
+# dot product scoring mlp layer, segmentation head, geometry encoder
+CONVERTED_PREFIXES = (
+    "backbone.",
+    "transformer.",
+    "dot_prod_scoring.",
+    "segmentation_head.",
+    "geometry_encoder.",
+)
+
+
+def model_layout():
+    """Conv permutations and parameter shapes of the MLX model, keyed by parameter name.
+
+    Every optional module is enabled: the published weights have to serve every
+    configuration, not just the one a particular caller happens to build.
+    """
+    # Imported here because model_builder imports this module at module level.
+    from sam3.model_builder import (
+        build_sam3_image_model_skeleton,
+        conv_weight_perms,
+        parameter_shapes,
+    )
+
+    model = build_sam3_image_model_skeleton(
+        enable_segmentation=True,
+        enable_inst_interactivity=True,
+    )
+    return conv_weight_perms(model), parameter_shapes(model)
+
+
+def validate_layout(mlx_weights, expected):
+    mismatched = {
+        k: (tuple(v.shape), expected[k])
+        for k, v in mlx_weights.items()
+        if k in expected and tuple(v.shape) != expected[k]
+    }
+    if mismatched:
+        details = "\n".join(
+            f"  {k}: converted {got}, model expects {exp}"
+            for k, (got, exp) in sorted(mismatched.items())
+        )
+        raise ValueError(
+            f"{len(mismatched)} converted weight(s) do not match the MLX model:\n{details}"
+        )
+
+    unknown = sorted(k for k in mlx_weights if k not in expected)
+    if unknown:
+        print(f"Warning: {len(unknown)} converted key(s) are not model parameters: {unknown}")
+
+
 def convert(model_path):
     weight_file = str(model_path / "sam3.pt")
     weights = torch.load(weight_file, map_location="cpu", weights_only=True)
 
+    perms, expected = model_layout()
+
     mlx_weights = dict()
     for k, v in weights.items():
-        # Vision Encoder
-        if "detector" in k:
-            k = k.replace("detector.", "")
-            # vision and language backbone
-            if k.startswith("backbone."):
-                v = mx.array(v.numpy())
-                if k in {
-                    "backbone.vision_backbone.convs.0.dconv_2x2_0.weight",
-                    "backbone.vision_backbone.convs.0.dconv_2x2_1.weight",
-                    "backbone.vision_backbone.convs.1.dconv_2x2.weight"
-                }:
-                    v = v.transpose(1, 2, 3, 0)
-                
-                if k in {
-                    "backbone.vision_backbone.trunk.patch_embed.proj.weight",
-                    "backbone.vision_backbone.convs.0.conv_1x1.weight",
-                    "backbone.vision_backbone.convs.0.conv_3x3.weight",
-                    "backbone.vision_backbone.convs.1.conv_1x1.weight",
-                    "backbone.vision_backbone.convs.1.conv_3x3.weight",
-                    "backbone.vision_backbone.convs.2.conv_1x1.weight",
-                    "backbone.vision_backbone.convs.2.conv_3x3.weight",
-                    "backbone.vision_backbone.convs.3.conv_1x1.weight",
-                    "backbone.vision_backbone.convs.3.conv_3x3.weight",
-                }:
-                    v = v.transpose(0, 2, 3, 1)
-                mlx_weights[k] = v
+        if "detector" not in k:
+            continue
 
-            # transformer fusion encoder, detr decoder
-            elif k.startswith("transformer."):
-                v = mx.array(v.numpy())
-                mlx_weights[k] = v
+        k = k.replace("detector.", "")
+        if not k.startswith(CONVERTED_PREFIXES):
+            continue
 
-            # dot product scoring mlp layer
-            elif k.startswith("dot_prod_scoring."):
-                v = mx.array(v.numpy())
-                mlx_weights[k] = v
-            
-            # segmentation_head
-            elif k.startswith("segmentation_head."):
-                v = mx.array(v.numpy())
-                if k in {
-                    "segmentation_head.pixel_decoder.conv_layers.0.weight",
-                    "segmentation_head.pixel_decoder.conv_layers.1.weight",
-                    "segmentation_head.pixel_decoder.conv_layers.2.weight",
-                    "segmentation_head.semantic_seg_head.weight",
-                    "segmentation_head.instance_seg_head.weight",
+        v = mx.array(v.numpy())
+        perm = perms.get(k)
+        if perm is not None and v.ndim == 4 and tuple(v.shape) != expected.get(k):
+            v = v.transpose(*perm)
+        mlx_weights[k] = v
 
-                }:
-                    v = v.transpose(0, 2, 3, 1)
-                mlx_weights[k] = v
-            
-            # geometry encoder
-            elif k.startswith("geometry_encoder."):
-                v = mx.array(v.numpy())
+        if k.endswith("in_proj_weight") or k.endswith("in_proj_bias"):
+            update_attn_keys(k, mlx_weights)
 
-                mlx_weights[k] = v
+    validate_layout(mlx_weights, expected)
 
-            if k.endswith("in_proj_weight") or k.endswith("in_proj_bias"):
-                update_attn_keys(k, mlx_weights)
-
-     
-    return mlx_weights 
+    return mlx_weights
 
 def download_and_convert(
     hf_repo: str = PYTORCH_REPO,

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -2,6 +2,7 @@ import os
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx.utils import tree_flatten
 
 from sam3.convert import load_from_hub, download_and_convert, MLX_COMMUNITY_REPO
 from sam3.model.sam3_image import Sam3Image
@@ -272,15 +273,31 @@ def _create_sam3_transformer(has_presence_token: bool = True):
 
     return TransformerWrapper(encoder=encoder, decoder=decoder, d_model=256)
 
+CONV_PERM = (0, 2, 3, 1)
+CONV_TRANSPOSE_PERM = (1, 2, 3, 0)
+
+
+def conv_weight_perms(model):
+    perms = {}
+    for name, module in model.named_modules():
+        if isinstance(module, nn.ConvTranspose2d):
+            perms[f"{name}.weight"] = CONV_TRANSPOSE_PERM
+        elif isinstance(module, nn.Conv2d):
+            perms[f"{name}.weight"] = CONV_PERM
+    return perms
+
+
+def parameter_shapes(model):
+    return {k: tuple(v.shape) for k, v in tree_flatten(model.parameters())}
+
+
 def _sanitize_conv_layout(model, weights):
-    from mlx.utils import tree_flatten
-    expected = {k: tuple(v.shape) for k, v in tree_flatten(model.parameters())}
-    for k in list(weights.keys()):
+    expected = parameter_shapes(model)
+    for k, perm in conv_weight_perms(model).items():
+        v = weights.get(k)
         exp = expected.get(k)
-        v = weights[k]
-        if exp is None or v.ndim != 4 or tuple(v.shape) == exp:
+        if v is None or exp is None or v.ndim != 4 or tuple(v.shape) == exp:
             continue
-        perm = (1, 2, 3, 0) if "dconv" in k else (0, 2, 3, 1)
         cand = mx.transpose(v, perm)
         if tuple(cand.shape) == exp:
             weights[k] = cand
@@ -308,16 +325,13 @@ def load_checkpoint(model, checkpoint_path):
             raise e
          
 
-def build_sam3_image_model(
+def build_sam3_image_model_skeleton(
     bpe_path=None,
-    checkpoint_path=None,
-    hf_repo=MLX_COMMUNITY_REPO,
-    local_weights_dir=None,
-    convert_from_pytorch=False,
     enable_segmentation=True,
     enable_inst_interactivity=False,
     compile=False
 ):
+    """Build the model with random weights — no checkpoint is downloaded or loaded."""
     if bpe_path is None:
         bpe_path = os.path.join(
             os.path.dirname(__file__), "..", "assets", "bpe_simple_vocab_16e6.txt.gz"
@@ -326,7 +340,7 @@ def build_sam3_image_model(
     vision_encoder = _create_vision_backbone(
         compile_mode=compile, enable_inst_interactivity=enable_inst_interactivity
     )
-    
+
     text_encoder = _create_text_encoder(bpe_path)
 
     backbone = _create_vl_backbone(vision_encoder, text_encoder)
@@ -343,12 +357,30 @@ def build_sam3_image_model(
 
     input_geometry_encoder = _create_geometry_encoder()
 
-    model = _create_sam3_model(
+    return _create_sam3_model(
         backbone,
         transformer,
         input_geometry_encoder,
         segmentation_head,
         dot_prod_scoring=dot_product_scoring
+    )
+
+
+def build_sam3_image_model(
+    bpe_path=None,
+    checkpoint_path=None,
+    hf_repo=MLX_COMMUNITY_REPO,
+    local_weights_dir=None,
+    convert_from_pytorch=False,
+    enable_segmentation=True,
+    enable_inst_interactivity=False,
+    compile=False
+):
+    model = build_sam3_image_model_skeleton(
+        bpe_path=bpe_path,
+        enable_segmentation=enable_segmentation,
+        enable_inst_interactivity=enable_inst_interactivity,
+        compile=compile,
     )
 
     if checkpoint_path is None:


### PR DESCRIPTION
## What

Follow-up to #9, as invited there: `convert.py` is now key-/shape-driven, so a re-convert of
`facebook/sam3` produces correctly laid-out weights instead of leaning on the load-time shim.

The old converter transposed the neck convs via two literal key sets. Anything outside those sets
was published in PyTorch (channels-first) layout — the 11 `sam2_convs.*` twins (built only when
`add_sam2_neck=True`) and `geometry_encoder.boxes_pool_project`.

## How

**`model_builder.py`**

- `build_sam3_image_model_skeleton(...)` — the module construction lifted out of
  `build_sam3_image_model`, without downloading or loading a checkpoint.
  `build_sam3_image_model` now calls it, so there is one construction path, not two.
- `conv_weight_perms(model)` walks `named_modules()` and maps every conv weight to its permutation
  by module type: `nn.ConvTranspose2d` → `(1, 2, 3, 0)`, `nn.Conv2d` → `(0, 2, 3, 1)` (the
  conventions already in `convert.py`). On this model it finds 29 weights — exactly the 29 4-D
  tensors in the checkpoint, no more and no fewer.
- `_sanitize_conv_layout` now uses that table, which retires the `"dconv" in k` name heuristic from
  #9. It stays as the compatibility shim for the weights already on the Hub and becomes a no-op
  once those are re-converted.

**`convert.py`**

- `convert()` builds the skeleton once and transposes a 4-D weight only when it is a conv parameter
  *and* its loaded shape differs from the shape the model expects — shape-guarded and idempotent.
  The five prefix branches collapse into one loop; every non-conv key is handled exactly as before.
- The skeleton is deliberately built with `enable_segmentation=True,
  enable_inst_interactivity=True`, independent of any caller's flags. Published weights have to
  serve every configuration, and reusing the caller's model here would silently re-introduce this
  exact bug for anyone converting with the defaults.
- `validate_layout()` raises if a converted weight disagrees with its parameter shape, so a layout
  regression can't be published silently again.

## Verification

Re-converted `facebook/sam3` (`sam3.pt`) with the new converter on Apple M5 Pro and diffed the
result against the published `mlx-community/sam3-image` weights, key by key:

```
convert() ok: 1400 keys in 0.8s (validation passed)
vs mlx-community/sam3-image: 1388 identical, 12 newly transposed, 0 other
   (256, 256, 1, 1)   -> (256, 1, 1, 256)    backbone.vision_backbone.sam2_convs.0.conv_1x1.weight
   (256, 256, 3, 3)   -> (256, 3, 3, 256)    backbone.vision_backbone.sam2_convs.0.conv_3x3.weight
   (1024, 512, 2, 2)  -> (512, 2, 2, 1024)   backbone.vision_backbone.sam2_convs.0.dconv_2x2_0.weight
   (512, 256, 2, 2)   -> (256, 2, 2, 512)    backbone.vision_backbone.sam2_convs.0.dconv_2x2_1.weight
   (256, 512, 1, 1)   -> (256, 1, 1, 512)    backbone.vision_backbone.sam2_convs.1.conv_1x1.weight
   (256, 256, 3, 3)   -> (256, 3, 3, 256)    backbone.vision_backbone.sam2_convs.1.conv_3x3.weight
   (1024, 512, 2, 2)  -> (512, 2, 2, 1024)   backbone.vision_backbone.sam2_convs.1.dconv_2x2.weight
   (256, 1024, 1, 1)  -> (256, 1, 1, 1024)   backbone.vision_backbone.sam2_convs.2.conv_1x1.weight
   (256, 256, 3, 3)   -> (256, 3, 3, 256)    backbone.vision_backbone.sam2_convs.2.conv_3x3.weight
   (256, 1024, 1, 1)  -> (256, 1, 1, 1024)   backbone.vision_backbone.sam2_convs.3.conv_1x1.weight
   (256, 256, 3, 3)   -> (256, 3, 3, 256)    backbone.vision_backbone.sam2_convs.3.conv_3x3.weight
   (256, 256, 7, 7)   -> (256, 7, 7, 256)    geometry_encoder.boxes_pool_project.weight
```

1388 weights come out bit-identical to what is on the Hub today; the 12 that were published
channels-first are now in MLX layout and nothing else moved.

On those re-converted weights:

- `_sanitize_conv_layout` touches **0** keys — the shim is a genuine no-op, with
  `enable_inst_interactivity` both `True` and `False`
- text prompt `"person"` → 2 boxes @ 0.954 / 0.772, and a box prompt → 0.9778, i.e. bit-for-bit the
  same numbers the published weights produce through the shim

Two more checks, independent of the checkpoint download:

- **Round-trip:** undoing the transposes on the 17 correctly-converted convs, leaving the 12 broken
  ones as they are, and re-prefixing with `detector.` reconstructs the converter's input;
  `convert()` on that yields 1400/1400 shapes matching the model, the 17 healthy convs bit-exact,
  the 12 broken ones transposed. `validate_layout` raises when a channels-first weight is injected,
  and the `in_proj_weight/bias → q/k/v` split still runs inside the new prefix filter.
- **No behaviour change in the shim:** the new `_sanitize_conv_layout` is bit-identical to the
  merged one across all 1400 published weights, for both `enable_inst_interactivity` settings.

The regenerated `model.safetensors` is sitting here — happy to open a PR against
`mlx-community/sam3-image` with it if that's the easiest path for you.
